### PR TITLE
fix: use GH_TOKEN for release step

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -40,6 +40,6 @@ jobs:
 
       - name: Update release with dist folder
         env:
-          BDP_UI_TOKEN: ${{ secrets.BDP_UI_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           gh release upload ${{ github.ref }} dist/** --clobber


### PR DESCRIPTION
see https://cli.github.com/manual/gh_auth_login#:~:text=To%20use%20gh%20in%20GitHub,or%20during%20the%20interactive%20prompting.