### PR TITLE
fix: svg attributes warning usage

### DIFF
--- a/src/components/footer/FooterSocials.tsx
+++ b/src/components/footer/FooterSocials.tsx
@@ -84,7 +84,7 @@ export const FooterSocials = (
       {...rest}
       className={`text-black mb-[6px] md:mb-0 dark:text-white flex w-fit max-w-full gap-[24px] ${classname}`} 
     >
-      {platforms.map((platform, index) => (
+      {platforms.map((platform) => (
         <Platform key={platform.entity} platform={platform} />
       ))}
     </div>


### PR DESCRIPTION
Naming [commit convention](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-angular) and [default rules](https://github.com/semantic-release/commit-analyzer/blob/HEAD/lib/default-release-rules.js) guides `semantic-release/commit-analyzer` to determine when to cut a release or not.
Usually commit name bubbles up to PR title.

However, in the last commit squashed and merged to main (#22) the pr title wasn't standard, and even though commits under the PR were standard, the title wasn't and hence no release was cut.
This PR adds a change but with the `fix:` as commit name to ensure a build is made and a release is cut from the latest src.

remove unused variable, re-trigger ci to build and release